### PR TITLE
fix: wrong headers type

### DIFF
--- a/lib/functions/HttpUtils.ts
+++ b/lib/functions/HttpUtils.ts
@@ -40,7 +40,7 @@ const openIdFetch = async <T>(
     exceptionOnHttpErrorStatus?: boolean;
   }
 ): Promise<OpenIDResponse<T>> => {
-  const headers = opts?.customHeaders ? opts.customHeaders : [];
+  const headers = opts?.customHeaders ? opts.customHeaders : {};
   if (opts?.bearerToken) {
     headers['Authorization'] = `Bearer ${opts.bearerToken}`;
   }


### PR DESCRIPTION
Changed the fallback `headers` to an empty object instead of array.

Fixes #18 

Signed-off-by: Karim Stekelenburg <karim@animo.id>