### PR TITLE
fix: ssi-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "node": ">=14"
   },
   "dependencies": {
+    "@sphereon/ssi-types": "^0.8.1-unstable.135",
     "cross-fetch": "^3.1.5",
     "debug": "^4.3.4",
     "uint8arrays": "^3.1.1"
   },
   "devDependencies": {
-    "@sphereon/ssi-types": "^0.8.1-unstable.135",
     "@types/jest": "^28.1.8",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",


### PR DESCRIPTION
The move of the `@sphereon/ssi-types` dependency to `devDependencies` broke my installation as the build includes imports to that package. 

Signed-off-by: Karim Stekelenburg <karim@animo.id>