### PR TITLE
fix: add scope to AccessTokenResponse

### DIFF
--- a/lib/types/Authorization.types.ts
+++ b/lib/types/Authorization.types.ts
@@ -68,7 +68,7 @@ export interface OpenIDResponse<T> {
 
 export interface AccessTokenResponse {
   access_token: string;
-  scope?: string
+  scope?: string;
   token_type?: string;
   expires_in?: number; // in seconds
   c_nonce?: string;

--- a/lib/types/Authorization.types.ts
+++ b/lib/types/Authorization.types.ts
@@ -68,6 +68,7 @@ export interface OpenIDResponse<T> {
 
 export interface AccessTokenResponse {
   access_token: string;
+  scope?: string
   token_type?: string;
   expires_in?: number; // in seconds
   c_nonce?: string;


### PR DESCRIPTION
I've noticed that the scope was not present on the `AccessTokenResponse`
type. However, the scope is set whenever using an issuer URI that
contains a `credential_type`.

Signed-off-by: Karim Stekelenburg <karim@animo.id>